### PR TITLE
Test PR and Installation tests. Bump chart version to 0.1.6, use an actual sorry-cypress version so the chart works out of the box

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -41,13 +41,10 @@ jobs:
         run: ct lint --all --debug --config lint.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v2.0.1
         with:
           install_local_path_provisioner: true
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0
-        with:
-          command: install
-          config: test.yaml
+        run: ct install --debug --config test.yaml

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: ct lint --all --debug --config lint.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v2.0.1
+        uses: helm/kind-action@v1.1.0
         with:
           install_local_path_provisioner: true
         if: steps.list-changed.outputs.changed == 'true'

--- a/helm-charts/charts/sorry-cypress/Chart.yaml
+++ b/helm-charts/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 1.16.0
 home: https://sorry-cypress.dev/
 sources:

--- a/helm-charts/charts/sorry-cypress/Chart.yaml
+++ b/helm-charts/charts/sorry-cypress/Chart.yaml
@@ -3,7 +3,7 @@ name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
 version: 0.1.6
-appVersion: 1.16.0
+appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:
 - https://github.com/sorry-cypress/sorry-cypress

--- a/lint.yaml
+++ b/lint.yaml
@@ -3,5 +3,3 @@ remote: origin
 target-branch: main
 chart-dirs:
   - helm-charts/charts
-all:
-debug:

--- a/test.yaml
+++ b/test.yaml
@@ -3,6 +3,4 @@ remote: origin
 target-branch: main
 chart-dirs:
   - helm-charts/charts
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 600s


### PR DESCRIPTION
This PR increases the chart version by 0.0.1. Primarily this was to test the linter and the installation tester.
These failed because I mistakenly chose a sorry-cypress tag that doesn't exist, so changed that in the Chart.yml to the latest non-beta version.