### PR TITLE
Add DASHBOARD_URL env to the director deployment

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.6
+version: 0.1.8
 appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/templates/deployment-dashboard.yml
+++ b/charts/sorry-cypress/templates/deployment-dashboard.yml
@@ -19,7 +19,7 @@ spec:
       - env:
         {{- range .Values.api.ingress.hosts }}
         - name: GRAPHQL_SCHEMA_URL
-          value: {{ .host }}
+          value: http://{{ .host }}
         {{- end }}
         {{- if .Values.dashboard.environmentVariables.ciUrl }}
         - name: CI_URL

--- a/charts/sorry-cypress/templates/deployment-dashboard.yml
+++ b/charts/sorry-cypress/templates/deployment-dashboard.yml
@@ -17,10 +17,8 @@ spec:
     spec:
       containers:
       - env:
-        {{- range .Values.api.ingress.hosts }}
         - name: GRAPHQL_SCHEMA_URL
-          value: http://{{ .host }}
-        {{- end }}
+          value: {{ .Values.dashboard.environmentVariables.graphQlSchemaUrl | quote }}
         {{- if .Values.dashboard.environmentVariables.ciUrl }}
         - name: CI_URL
           value: {{ .Values.dashboard.environmentVariables.ciUrl | quote }}

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -15,10 +15,8 @@ spec:
     spec:
       containers:
       - env:
-        {{- range .Values.dashboard.ingress.hosts }}
         - name: DASHBOARD_URL
-          value: http://{{ .host }}
-        {{- end }}
+          value: {{ .Values.director.environmentVariables.dashboardUrl | quote }}
         - name: ALLOWED_KEYS
           value: {{ .Values.director.environmentVariables.allowedKeys }}
         - name: EXECUTION_DRIVER

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -17,11 +17,11 @@ spec:
       - env:
         {{- range .Values.director.ingress.hosts }}
         - name: director_URL
-          value: {{ .host }}
+          value: http://{{ .host }}
         {{- end }}
         {{- range .Values.dashboard.ingress.hosts }}
         - name: DASHBOARD_URL
-          value: {{ .host }}
+          value: http://{{ .host }}
         {{- end }}
         - name: ALLOWED_KEYS
           value: {{ .Values.director.environmentVariables.allowedKeys }}

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -19,6 +19,10 @@ spec:
         - name: director_URL
           value: {{ .host }}
         {{- end }}
+        {{- range .Values.dashboard.ingress.hosts }}
+        - name: DASHBOARD_URL
+          value: {{ .host }}
+        {{- end }}
         - name: ALLOWED_KEYS
           value: {{ .Values.director.environmentVariables.allowedKeys }}
         - name: EXECUTION_DRIVER

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -15,10 +15,6 @@ spec:
     spec:
       containers:
       - env:
-        {{- range .Values.director.ingress.hosts }}
-        - name: director_URL
-          value: http://{{ .host }}
-        {{- end }}
         {{- range .Values.dashboard.ingress.hosts }}
         - name: DASHBOARD_URL
           value: http://{{ .host }}

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -35,7 +35,6 @@ api:
     #    hosts:
     #      - chart-example.local
 
-
 dashboard:
   image:
     repository: agoldis/sorry-cypress-dashboard
@@ -55,8 +54,9 @@ dashboard:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # https://sorry-cypress.dev/dashboard#configuration
   environmentVariables:
-    # https://sorry-cypress.dev/dashboard#configuration
+    graphQlSchemaUrl: ""
     ciUrl: ""
 
   service:
@@ -74,7 +74,6 @@ dashboard:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
-
 
 director:
   image:
@@ -97,18 +96,18 @@ director:
 
   environmentVariables:
     # In memory, or Mongo.
-      # Valid options are:
-      # "../execution/in-memory"
-      # "../execution/mongo/driver"
+    # Valid options are:
+    # "../execution/in-memory"
+    # "../execution/mongo/driver"
     executionDriver: "../execution/in-memory"
 
     # Ignored if mongo.environmentVariables.executionDriver is set to "../execution/in-memory"
     mongodbDatabase: sorry-cypress
 
     # Dummy or S3
-      # Valid options are:
-      # "../screenshots/dummy.driver"
-      # "../screenshots/s3.driver"
+    # Valid options are:
+    # "../screenshots/dummy.driver"
+    # "../screenshots/s3.driver"
     screenshotsDriver: "../screenshots/dummy.driver"
 
     # https://sorry-cypress.dev/director/configuration

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -95,6 +95,9 @@ director:
     #   memory: 128Mi
 
   environmentVariables:
+    # The "Run URL" in the Cypress client
+    dashboardUrl: ""
+
     # In memory, or Mongo.
     # Valid options are:
     # "../execution/in-memory"


### PR DESCRIPTION
This pull-request adds the missing `DASHBOARD_URL` director's environment variable.
It also converts ingress hosts to URLs, so the interaction works properly.