### PR TITLE
Allow external mongo service

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:
-- https://github.com/sorry-cypress/sorry-cypress
+  - https://github.com/sorry-cypress/sorry-cypress
 icon: https://sorry-cypress.dev/public/octolumbercat.png
 maintainers:
   - name: tico24

--- a/charts/sorry-cypress/templates/_helpers.tpl
+++ b/charts/sorry-cypress/templates/_helpers.tpl
@@ -69,3 +69,14 @@ Create the s3 secret
 {{- printf .secretAccessKey | b64enc -}}
 {{- end }}
 {{- end }}
+
+{{/*
+  Determine the MongoDB hostname.
+*/}}
+{{- define "mongo.hostname" -}}
+{{- if .Values.mongo.enabled }}
+{{- printf "%s-%s" (include "sorry-cypress-helm.fullname" .) "mongo" -}}
+{{- else }}
+{{- printf "%s" .Values.mongo.mongoServer -}}
+{{- end }}
+{{- end }}

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -27,7 +27,7 @@ spec:
         - name: MONGODB_DATABASE
           value: {{ .Values.director.environmentVariables.mongodbDatabase }}
         - name: MONGODB_URI
-          value: mongodb://{{ include "sorry-cypress-helm.fullname" . }}-mongo:{{ .Values.mongo.service.port }}
+          value: mongodb://{{ include "mongo.hostname" . }}:{{ .Values.mongo.service.port }}
         {{- end }}
         - name: SCREENSHOTS_DRIVER
           value: {{ .Values.director.environmentVariables.screenshotsDriver }}

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -35,7 +35,6 @@ api:
     #    hosts:
     #      - chart-example.local
 
-
 dashboard:
   image:
     repository: agoldis/sorry-cypress-dashboard
@@ -75,7 +74,6 @@ dashboard:
     #    hosts:
     #      - chart-example.local
 
-
 director:
   image:
     repository: agoldis/sorry-cypress-director
@@ -97,18 +95,18 @@ director:
 
   environmentVariables:
     # In memory, or Mongo.
-      # Valid options are:
-      # "../execution/in-memory"
-      # "../execution/mongo/driver"
+    # Valid options are:
+    # "../execution/in-memory"
+    # "../execution/mongo/driver"
     executionDriver: "../execution/in-memory"
 
     # Ignored if mongo.environmentVariables.executionDriver is set to "../execution/in-memory"
     mongodbDatabase: sorry-cypress
 
     # Dummy or S3
-      # Valid options are:
-      # "../screenshots/dummy.driver"
-      # "../screenshots/s3.driver"
+    # Valid options are:
+    # "../screenshots/dummy.driver"
+    # "../screenshots/s3.driver"
     screenshotsDriver: "../screenshots/dummy.driver"
 
     # https://sorry-cypress.dev/director/configuration
@@ -140,6 +138,10 @@ director:
 mongo:
   # You need to ensure that mongo.environmentVariables.executionDriver is set to "../execution/mongo/driver" if you want mongo.enabled to be true.
   enabled: false
+
+  # To use an external MongoDB instance, set enabled to false and uncomment
+  # the line below:
+  # mongoServer: ""
 
   image:
     repository: mongo


### PR DESCRIPTION
This pull-request allows skipping mongo deploy but setting an external one, by adding a `mongo.mongoServer` property to values (to be used with `enabled: false`