### PR TITLE
Move `director.environmentVariables.mongodbDatabase` to `mongo.mongoDatabase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ https://sorry-cypress.dev/director/configuration
 | `director.environmentVariables.allowedKeys`       | Define the list of comma delimited record keys (provided to the Cypress Runner using `--key` option). Empty or not provided variable means that all record keys are allowed. | `""`                             |
 | `dashboard.environmentVariables.dashboardUrl`     | The "Run URL" in the Cypress client                                                                                                                                          | `""`                             |
 | `director.environmentVariables.executionDriver`   | Set the execution driver. Valid options are `"../execution/in-memory"` and `"../execution/mongo/driver"`                                                                     | `"../execution/in-memory"`       |
-| `director.environmentVariables.mongodbDatabase`   | Set the MongoDB database, if the execution driver is set to `"../execution/mongo/driver"`                                                                                    | `sorry-cypress`                  |
 | `director.environmentVariables.screenshotsDriver` | Set the screenshots driver. Valid options are `"../screenshots/dummy.driver"` and `"../screenshots/s3.driver"`                                                               | `"../screenshots/dummy.driver"`  |
 | `director.s3.bucketName`                          | Set the screenshots storage bucket name, if the screenshots driver is set to `"../screenshots/s3.driver"`                                                                    | `example-bucket`                 |
 | `director.s3.region`                              | Set the screenshots storage bucket region, if the screenshots driver is set to `"../screenshots/s3.driver"`                                                                  | `us-east-1`                      |
@@ -113,11 +112,12 @@ https://sorry-cypress.dev/director/configuration
 
 ### Mongo service
 
-If the execution driver is set to `"../execution/mongo/driver"`, you may enable to MongoDB service deploy or provide an external one. Ignore this configuration when using other execution drivers.
+If the execution driver is set to `"../execution/mongo/driver"`, you may enable the internal MongoDB service deploy or provide an external one. Ignore this configuration when using other execution drivers.
 
 | Parameter                      | Description                                                                        | Default         |
 | ------------------------------ | ---------------------------------------------------------------------------------- | --------------- |
 | `mongo.enabled`                | If enabled, it will deploy the internal MongoDB service.                           | `false`         |
+| `mongo.mongoDatabase`          | The mongo database                                                                 | `sorry-cypress` |
 | `mongo.mongoServer`            | The mongo server when providing an external one. Use it with `mongo.enabled=false` | `""`            |
 | `mongo.image.repository`       | Image repository                                                                   | `mongo`         |
 | `mongo.image.tag`              | Image tag                                                                          | `"4.0"`         |

--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/templates/deployment-api.yml
+++ b/charts/sorry-cypress/templates/deployment-api.yml
@@ -19,9 +19,9 @@ spec:
       - env:
         {{- if eq .Values.director.environmentVariables.executionDriver "../execution/mongo/driver" }}
         - name: MONGODB_DATABASE
-          value: sorry-cypress
+          value: {{ .Values.mongo.mongoDatabase }}
         - name: MONGODB_URI
-          value: mongodb://{{ include "sorry-cypress-helm.fullname" . }}-mongo:{{ .Values.mongo.service.port }}
+          value: mongodb://{{ include "mongo.hostname" . }}:{{ .Values.mongo.service.port }}
         {{- end }}
         image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.api.image.pullPolicy }}

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -23,7 +23,7 @@ spec:
           value: {{ .Values.director.environmentVariables.executionDriver }}
         {{- if eq .Values.director.environmentVariables.executionDriver "../execution/mongo/driver" }}
         - name: MONGODB_DATABASE
-          value: {{ .Values.director.environmentVariables.mongodbDatabase }}
+          value: {{ .Values.mongo.mongoDatabase }}
         - name: MONGODB_URI
           value: mongodb://{{ include "mongo.hostname" . }}:{{ .Values.mongo.service.port }}
         {{- end }}

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -104,9 +104,6 @@ director:
     # "../execution/mongo/driver"
     executionDriver: "../execution/in-memory"
 
-    # Ignored if mongo.environmentVariables.executionDriver is set to "../execution/in-memory"
-    mongodbDatabase: sorry-cypress
-
     # Dummy or S3
     # Valid options are:
     # "../screenshots/dummy.driver"
@@ -141,11 +138,11 @@ director:
 
 mongo:
   # You need to ensure that mongo.environmentVariables.executionDriver is set to "../execution/mongo/driver" if you want mongo.enabled to be true.
-  enabled: false
 
-  # To use an external MongoDB instance, set enabled to false and uncomment
-  # the line below:
-  # mongoServer: ""
+  mongoDatabase: "sorry-cypress"
+
+  # Ignored if mongo.enabled is set to true
+  mongoServer: ""
 
   image:
     repository: mongo

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -138,6 +138,7 @@ director:
 
 mongo:
   # You need to ensure that mongo.environmentVariables.executionDriver is set to "../execution/mongo/driver" if you want mongo.enabled to be true.
+  enabled: false
 
   mongoDatabase: "sorry-cypress"
 


### PR DESCRIPTION
Since API and director services depend on the mongo server/database, which may or not be external, I thought we should move all the mongo related configs to the `mongo` section. 

Actually, in both deployments, the mongo port was read from `mongo.service.port` in the `MONGODB_URI`, and then this PR just standardizes this behavior.