### PR TITLE
Allow ingress path customization

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.23
+version: 0.1.24
 appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/README.md
+++ b/charts/sorry-cypress/README.md
@@ -70,6 +70,7 @@ https://sorry-cypress.dev/api#configuration
 | `api.ingress.labels`        | Ingress labels                        | `{}`                        |
 | `api.ingress.annotations`   | Ingress annotations                   | `{}`                        |
 | `api.ingress.hosts[0].host` | Hostname to the service installation  | `api.chart-example.local`   |
+| `api.ingress.hosts[0].path` | Root path to the service installation | `/`                         |
 | `api.ingress.tls`           | Ingress secrets for TLS certificates  | `[]`                        |
 
 ### Dashboard service
@@ -92,6 +93,7 @@ https://sorry-cypress.dev/dashboard#configuration
 | `dashboard.ingress.labels`                                | Ingress labels                                                                                             | `{}`                              |
 | `dashboard.ingress.annotations`                           | Ingress annotations                                                                                        | `{}`                              |
 | `dashboard.ingress.hosts[0].host`                         | Hostname to the service installation                                                                       | `dashboard.chart-example.local`   |
+| `dashboard.ingress.hosts[0].path`                         | Root path to the service installation                                                                      | `/`                               |
 | `dashboard.ingress.tls`                                   | Ingress secrets for TLS certificates                                                                       | `[]`                              |
 
 ### Director service

--- a/charts/sorry-cypress/templates/ingress-api.yml
+++ b/charts/sorry-cypress/templates/ingress-api.yml
@@ -38,7 +38,7 @@ spec:
       http:
         paths:
           {{- if $v1Networking }}
-          - path: /
+          - path: {{ .path | quote }}
             pathType: Prefix
             backend:
               service:
@@ -46,7 +46,8 @@ spec:
                 port:
                   number: {{ $servicePort }}
           {{- else }}
-          - backend:
+            - path: {{ .path | quote }}
+              backend:
               serviceName: {{ $fullName }}-api
               servicePort: {{ $servicePort }}
           {{- end }}

--- a/charts/sorry-cypress/templates/ingress-api.yml
+++ b/charts/sorry-cypress/templates/ingress-api.yml
@@ -46,7 +46,7 @@ spec:
                 port:
                   number: {{ $servicePort }}
           {{- else }}
-            - path: {{ .path | quote }}
+            - path: {{ .path | default "/" }}
               backend:
               serviceName: {{ $fullName }}-api
               servicePort: {{ $servicePort }}

--- a/charts/sorry-cypress/templates/ingress-api.yml
+++ b/charts/sorry-cypress/templates/ingress-api.yml
@@ -38,7 +38,7 @@ spec:
       http:
         paths:
           {{- if $v1Networking }}
-          - path: {{ .path | quote }}
+          - path: {{ .path | default "/" }}
             pathType: Prefix
             backend:
               service:

--- a/charts/sorry-cypress/templates/ingress-dashboard.yml
+++ b/charts/sorry-cypress/templates/ingress-dashboard.yml
@@ -38,7 +38,7 @@ spec:
       http:
         paths:
           {{- if $v1Networking }}
-          - path: {{ .path | quote }}
+          - path: {{ .path | default "/" }}
             pathType: Prefix
             backend:
               service:

--- a/charts/sorry-cypress/templates/ingress-dashboard.yml
+++ b/charts/sorry-cypress/templates/ingress-dashboard.yml
@@ -38,7 +38,7 @@ spec:
       http:
         paths:
           {{- if $v1Networking }}
-          - path: /
+          - path: {{ .path | quote }}
             pathType: Prefix
             backend:
               service:
@@ -46,7 +46,8 @@ spec:
                 port:
                   number: {{ $servicePort }}
           {{- else }}
-          - backend:
+          - path: {{ .path | quote }}
+            backend:
               serviceName: {{ $fullName }}-dashboard
               servicePort: {{ $servicePort }}
           {{- end }}

--- a/charts/sorry-cypress/templates/ingress-dashboard.yml
+++ b/charts/sorry-cypress/templates/ingress-dashboard.yml
@@ -46,7 +46,7 @@ spec:
                 port:
                   number: {{ $servicePort }}
           {{- else }}
-          - path: {{ .path | quote }}
+          - path: {{ .path | default "/" }}
             backend:
               serviceName: {{ $fullName }}-dashboard
               servicePort: {{ $servicePort }}

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -37,6 +37,7 @@ api:
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: api.chart-example.local
+        path: /
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
@@ -84,7 +85,7 @@ dashboard:
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: dashboard.chart-example.local
-        paths: /
+        path: /
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
This pull-request allows ingress path customization for `dashboard` and `api` services.

This allows both services to be in the same host, using the path to route to the proper service.

Note: no breaking changes were introduced, since the default ingress path still is `/`.

By the way, the [AWS installation guide](https://sorry-cypress.dev/installation/aws) have this scenario:
![image](https://user-images.githubusercontent.com/968790/106331629-08dec180-6264-11eb-906e-d45b5236480f.png)
