### PR TITLE
[skip release] Add "[skip release]" flag for commits

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
-    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     strategy:
       matrix:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip release]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Do not run release when commit message contains `[skip release]`.

Motivation being:
- update documentation without invoking CI
- anything else that doesn't require ci