### PR TITLE
Always enable API readiness probes

### DIFF
--- a/charts/sorry-cypress/templates/deployment-api.yml
+++ b/charts/sorry-cypress/templates/deployment-api.yml
@@ -48,7 +48,6 @@ spec:
         - containerPort: 4000
         resources:
           {{- toYaml .Values.api.resources | nindent 10 }}
-        {{- if .Values.api.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /.well-known/apollo/server-health
@@ -57,7 +56,6 @@ spec:
           timeoutSeconds: {{ .Values.api.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.api.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.api.readinessProbe.failureThreshold }}
-        {{- end }}
       restartPolicy: Always
       serviceAccountName: ""
       volumes: null

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -34,7 +34,6 @@ api:
     port: 4000
 
   readinessProbe:
-    enabled: true
     periodSeconds: 5
     timeoutSeconds: 3
     successThreshold: 2


### PR DESCRIPTION
This signifies that we only support sorry cypress 1.x going forward.