### PR TITLE
Add missing Minio PORT and USE_SSL configurations to Director deployment

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.1.0
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -92,6 +92,12 @@ spec:
           value: {{ .Values.minio.endpoint }}
         - name: MINIO_URL
           value: {{ .Values.minio.url }}
+        - name: MINIO_PORT
+          value: {{ .Values.minio.service.port }}
+        {{- if eq .Values.minio.service.port "443" }}
+        - name: MINIO_USESSL
+          value: "true"
+        {{- end }}
         {{- end }}
         image: "{{ .Values.director.image.repository }}:{{ .Values.director.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.director.image.pullPolicy }}


### PR DESCRIPTION
The Director deployment doesn't have any configuration for MINIO_PORT and MINIO_USESSL

Grab the PORT value from the minio service. If the PORT value is 443 then set USE_SSL to true