### PR TITLE
Ensure MINIO_PORT env variable is injected as string

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.0.5
+version: 1.0.6
 appVersion: 1.1.0
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -93,7 +93,7 @@ spec:
         - name: MINIO_URL
           value: {{ .Values.minio.url }}
         - name: MINIO_PORT
-          value: {{ .Values.minio.service.port }}
+          value: {{ .Values.minio.service.port | quote }}
         {{- if eq .Values.minio.service.port "443" }}
         - name: MINIO_USESSL
           value: "true"


### PR DESCRIPTION
Fixing issue created in https://github.com/sorry-cypress/charts/pull/65

Ran into the following issue https://github.com/kubernetes/kubernetes/issues/82296 where integer environment variables need to be quoted

Use the `quote` template function to ensure that `minio.service.port` is injected as a string