### PR TITLE
Ensure inactivity timeout env var is injected as string

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.1.0
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -100,7 +100,7 @@ spec:
         {{- end }}
         {{- end }}
         - name: INACTIVITY_TIMEOUT_SECONDS
-          value: {{ .Values.director.environmentVariables.inactivityTimeoutSeconds }}
+          value: {{ .Values.director.environmentVariables.inactivityTimeoutSeconds | quote }}
         image: "{{ .Values.director.image.repository }}:{{ .Values.director.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.director.image.pullPolicy }}
         name: {{ include "sorry-cypress-helm.fullname" . }}-director


### PR DESCRIPTION
Accidentally broke this in https://github.com/sorry-cypress/charts/pull/68, make sure it's quoted correctly