### PR TITLE
Add support for authentication using IAM role for ServiceAccounts on EKS

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.1.3
+version: 1.2.0
 appVersion: 1.1.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/README.md
+++ b/charts/sorry-cypress/README.md
@@ -124,7 +124,9 @@ https://sorry-cypress.dev/director/configuration
 
 | Parameter                                         | Description                                                                                                                                                                  | Default                          |
 |---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
-| `director.serviceAccountName`                     | Service account to be assumed by the director                                                  
+| `director.serviceAccount.name`                    | Service account to be assumed by the director                                                                                                                                | `~`                              |
+| `director.serviceAccount.create`                  | Set to create the service account for the director                                                                                                                           | `false`                          |
+| `director.serviceAccount.annotations`             | Annotations to set on the service account if created                                                                                                                         | `[]`                             |
 | `director.image.repository`                       | Image repository                                                                                                                                                             | `agoldis/sorry-cypress-director` |
 | `director.image.tag`                              | Image tag                                                                                                                                                                    | ``                               |
 | `director.image.pullPolicy`                       | Image pull policy                                                                                                                                                            | `Always`                         |
@@ -186,6 +188,23 @@ https://sorry-cypress.dev/director/storage
 | `s3.ingress.hosts[0].host`    | Hostname to the service installation                                                                              | `static.chart-example.local` |
 | `s3.ingress.hosts[0].path`    | Root path to the service installation                                                                             | `/`                          |
 | `s3.ingress.tls`              | Ingress secrets for TLS certificates                                                                              | `[]`                         |
+
+### IAM roles for AWS EKS Service Accounts
+
+Rather than specifying a static IAM Access Key, on EKS it's possible for a pod to assume an IAM Role instead, which means no sensitive credentials are needed.
+
+Using `director.serviceAccount` properties a service account can be created for the director, assigning the IAM Role ARN:
+
+```yaml
+director:
+  serviceAccount:
+    name: sorry-cypress-director
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
+```
+
+See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html for further information on the IAM Role and associating the EKS Identity Provider to IAM.
 
 ### MinIO
 

--- a/charts/sorry-cypress/README.md
+++ b/charts/sorry-cypress/README.md
@@ -204,7 +204,7 @@ director:
       eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
 ```
 
-See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html for further information on the IAM Role and associating the EKS Identity Provider to IAM.
+See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html for further information on the IAM Role and associating the EKS Identity Provider to IAM.
 
 ### MinIO
 

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,3 +1,7 @@
+# 1.2.0
+## Update
+Add support for authentication using IAM role for ServiceAccounts on EKS
+
 # 1.1.1
 ## Update
 Director serviceaccount name is now user-editable (via values)

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -2,6 +2,8 @@
 ## Update
 Add support for authentication using IAM role for ServiceAccounts on EKS
 
+`director.serviceAccountName` changed to `director.serviceAccount.name` with backwards compatibility for the former
+
 # 1.1.1
 ## Update
 Director serviceaccount name is now user-editable (via values)

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -109,7 +109,7 @@ spec:
         resources:
           {{- toYaml .Values.director.resources | nindent 10 }}
       restartPolicy: Always
-      {{- with .Values.director.serviceAccountName }}
+      {{- with (.Values.director.serviceAccount.name | default .Values.director.serviceAccountName) }}
       serviceAccountName: {{ . | quote }}
       {{- end }}
       volumes: null

--- a/charts/sorry-cypress/templates/serviceaccount-director.yml
+++ b/charts/sorry-cypress/templates/serviceaccount-director.yml
@@ -9,4 +9,3 @@ metadata:
   {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}
-diff --git a/charts/sorry-cypress/templates/deployment-director.yml b/charts/sorry-cypress/templates/deployment-director.yml

--- a/charts/sorry-cypress/templates/serviceaccount-director.yml
+++ b/charts/sorry-cypress/templates/serviceaccount-director.yml
@@ -1,0 +1,12 @@
+{{- if .Values.director.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.director.serviceAccount.name }}
+  labels:
+    app: {{ include "sorry-cypress-helm.fullname" . }}-director
+  {{- with (pick .Values.director.serviceAccount "annotations") }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+diff --git a/charts/sorry-cypress/templates/deployment-director.yml b/charts/sorry-cypress/templates/deployment-director.yml

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -131,7 +131,14 @@ dashboard:
     #      - chart-example.local
 
 director:
-  serviceAccountName: "default"
+  serviceAccount:
+    name: ~
+    create: false
+    annotations: []
+    # Alternative aws-sdk authentication via IAM Roles for AWS EKS Service Accounts
+    # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+    #  eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
+
   image:
     repository: agoldis/sorry-cypress-director
     pullPolicy: Always


### PR DESCRIPTION
Using https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html on EKS, we can more securely pass authentication credentials via a service account with an annotation linking it to an IAM role EKS can assume to provide a Web Identity Token to the pod, which the aws-sdk picks up to use for authentication.