### PR TITLE
Add imagePullSecrets section to templates

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.4.5
+version: 1.4.6
 appVersion: 2.1.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/README.md
+++ b/charts/sorry-cypress/README.md
@@ -59,6 +59,7 @@ https://sorry-cypress.dev/api#configuration
 | Parameter                             | Description                                                                                  | Default                     |
 |---------------------------------------|----------------------------------------------------------------------------------------------|-----------------------------|
 | `.fullnameOverride`                   | Allows you to override the name of the chart.                                                | ``                          |
+| `imagePullSecrets`                    | An array of imagePullSecrets used to download images from a private registry.                | `[]`                        |
 ### API service
 
 https://sorry-cypress.dev/api#configuration
@@ -135,7 +136,7 @@ https://sorry-cypress.dev/director/configuration
 | `director.environmentVariables.dashboardUrl`      | The "Run URL" in the Cypress client                                                                                                                                          | `""`                             |
 | `director.environmentVariables.executionDriver`   | Set the execution driver. Valid options are `"../execution/in-memory"` and `"../execution/mongo/driver"`                                                                     | `"../execution/in-memory"`       |
 | `director.environmentVariables.screenshotsDriver` | Set the screenshots driver. Valid options are `"../screenshots/dummy.driver"` and `"../screenshots/s3.driver"`                                                               | `"../screenshots/dummy.driver"`  |
-| `director.environmentVariables.inactivityTimeoutSeconds`       | Set the timeout of all test runs under your projects. |  `180s` | 
+| `director.environmentVariables.inactivityTimeoutSeconds`       | Set the timeout of all test runs under your projects. |  `180s` |
 | `director.podAnnotations`                         | Set annotations for pods                                                                                                                                                     | `{}`                             |
 | `director.podLabels`                              | Set additional labels for pods                                                                                                                                               | `{}`                             |
 | `director.affinity`                               | Set affinity for pods                                                                                                                                                        | `{}`                             |

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,3 +1,8 @@
+# 1.4.6
+
+## Update
+Adds the standard `imagePullSecrets` section to the `api`, `dashboard` and `director` templates, which allow downloading images from a private registry.
+
 # 1.4.5
 
 ## Bugfix

--- a/charts/sorry-cypress/templates/deployment-api.yml
+++ b/charts/sorry-cypress/templates/deployment-api.yml
@@ -23,6 +23,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       nodeSelector:
         {{ toYaml .Values.api.nodeSelector | nindent 8 }}
       {{- with .Values.api.tolerations }}

--- a/charts/sorry-cypress/templates/deployment-dashboard.yml
+++ b/charts/sorry-cypress/templates/deployment-dashboard.yml
@@ -23,6 +23,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       nodeSelector:
         {{ toYaml .Values.dashboard.nodeSelector | nindent 8 }}
       {{- with .Values.dashboard.tolerations }}

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -20,6 +20,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       nodeSelector:
         {{ toYaml .Values.director.nodeSelector | nindent 8 }}
       {{- with .Values.director.tolerations }}

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -313,6 +313,6 @@ runCleaner:
   schedule: '0 1 * * *'
 
 imagePullSecrets: []
-# An optional array of imagePullSecrets that are used to download images froma  private registry
+# An optional array of imagePullSecrets that are used to download images from a private registry
 # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 # - name: <secret-name>

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -311,3 +311,8 @@ runCleaner:
   daysToKeep: 200
   # Run every morning at 1am by default.
   schedule: '0 1 * * *'
+
+imagePullSecrets: []
+# An optional array of imagePullSecrets that are used to download images froma  private registry
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# - name: <secret-name>


### PR DESCRIPTION
Adds the standard `imagePullSecrets` section to the `api`, `dashboard` and `director` templates.

Closes #95 

References:
https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/