### PR TITLE
Allow director service port to be configured

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.4.6
+version: 1.4.7
 appVersion: 2.1.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,3 +1,8 @@
+# 1.4.7
+
+## Bugfix
+Fixes an issue that prevented the director service port being changed to anything other than `1234`.
+
 # 1.4.6
 
 ## Update

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -39,6 +39,8 @@ spec:
           value: {{ .Values.director.environmentVariables.dashboardUrl | quote }}
         - name: ALLOWED_KEYS
           value: {{ .Values.director.environmentVariables.allowedKeys }}
+        - name: PORT
+          value: {{ .Values.director.service.port }}
         - name: EXECUTION_DRIVER
           value: {{ .Values.director.environmentVariables.executionDriver }}
         {{- if eq .Values.director.environmentVariables.executionDriver "../execution/mongo/driver" }}

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -40,7 +40,7 @@ spec:
         - name: ALLOWED_KEYS
           value: {{ .Values.director.environmentVariables.allowedKeys }}
         - name: PORT
-          value: {{ .Values.director.service.port }}
+          value: {{ .Values.director.service.port | quote }}
         - name: EXECUTION_DRIVER
           value: {{ .Values.director.environmentVariables.executionDriver }}
         {{- if eq .Values.director.environmentVariables.executionDriver "../execution/mongo/driver" }}


### PR DESCRIPTION
The director service is still coming up and listening on port `1234` when I set the director service port to a different port, e.g.:

```
    yamlencode({
      director = {
        service = {
          port = 80
        }
      }
```

This change populates the `PORT` environment variable with the `.Values.director.service.port` value, which should hopefully fix this issue.

https://docs.sorry-cypress.dev/configuration/director-configuration#common-configuration