### PR TITLE
Change the docs url for the dashboard configuration

### DIFF
--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -134,7 +134,7 @@ dashboard:
 
   initContainers: []
 
-  # https://sorry-cypress.dev/dashboard#configuration
+  # https://docs.sorry-cypress.dev/configuration/dashboard-configuration/configuration
   environmentVariables:
     graphQlClientCredentials: ""
     graphQlSchemaUrl: ""


### PR DESCRIPTION
Hi! Just making a small PR for a broken url I found in the values file while setting things up. (The old url redirects to the sorry-cypress.dev homepage currently.)

Thanks by the way for maintaining this helm chart. I set up sorry-cypress two years or so back on kubernetes, and it wasn't the most fun to manage the separate MongoDB and plain yaml manifests. The chart is very much appreciated. :+1: :+1: 