### PR TITLE
Override-able pathType in ingress

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.5.0
+version: 1.4.11
 appVersion: 2.1.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.4.10
+version: 1.5.0
 appVersion: 2.1.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,3 +1,8 @@
+# 1.4.11
+
+## Update
+Makes pathType configurable per ingress. `.Values.(api|dashboard|...).ingress.hosts.*.pathType`. Default retained at: `Prefix`
+
 # 1.4.10
 
 ## Update

--- a/charts/sorry-cypress/templates/ingress-api.yml
+++ b/charts/sorry-cypress/templates/ingress-api.yml
@@ -32,7 +32,7 @@ spec:
       http:
         paths:
           - path: {{ .path | default "/" }}
-            pathType: Prefix
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}-api

--- a/charts/sorry-cypress/templates/ingress-dashboard.yml
+++ b/charts/sorry-cypress/templates/ingress-dashboard.yml
@@ -32,7 +32,7 @@ spec:
       http:
         paths:
           - path: {{ .path | default "/" }}
-            pathType: Prefix
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}-dashboard

--- a/charts/sorry-cypress/templates/ingress-director.yml
+++ b/charts/sorry-cypress/templates/ingress-director.yml
@@ -32,7 +32,7 @@ spec:
       http:
         paths:
           - path: {{ .path | default "/" }}
-            pathType: Prefix
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}-director

--- a/charts/sorry-cypress/templates/ingress-s3.tpl
+++ b/charts/sorry-cypress/templates/ingress-s3.tpl
@@ -31,7 +31,7 @@ spec:
       http:
         paths:
           - path: {{ .path | default "/" }}
-            pathType: Prefix
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}-s3


### PR DESCRIPTION
Some (mostly older) take issues when combining the `"Prefix"` pathType and path values like `"/*"`. I such cases, instead of using prefix type, we often use ImplementationSpecific type instead.
Prefix is hardcoded now.