### PR TITLE
Allow file reads from minio

### DIFF
--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -346,6 +346,7 @@ minio:
   defaultBucket:
     enabled: true
     name: sorry-cypress
+    policy: download
 
   persistence:
     size: 10Gi


### PR DESCRIPTION
By default minio files are not allowed read. sorry-cypress bucket needs read permissions to show on sorry cypress dashboard.

https://github.com/sorry-cypress/sorry-cypress/issues/575