### PR TITLE
Add custom mongodb secret name and key

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.5.2
+version: 1.5.3
 appVersion: 2.1.6
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/README.md
+++ b/charts/sorry-cypress/README.md
@@ -160,16 +160,17 @@ https://sorry-cypress.dev/director/configuration
 
 If the execution driver is set to `"../execution/mongo/driver"`, you may enable the internal MongoDB service deploy or provide an external one. Ignore this configuration when using other execution drivers.
 
-| Parameter                      | Description                                                                        | Default         |
-|--------------------------------|------------------------------------------------------------------------------------|-----------------|
-| `mongodb.internal_db.enabled`    | If enabled, it will deploy the internal MongoDB service.                           | `true`          |
-| `mongodb.external_db.enabled`    | If enabled, it will allow you to use an external mongodb                           | `false`          |
-| `mongodb.external_db.mongoServer`| The mongo server when providing an external one. Use it with `mongodb.internal_db.enabled=false` | `""`            |
-| `mongodb.mongoDatabase`          | The mongo database                                                                 | `sorry-cypress` |
-| `mongodb.mongoConnectionString`  | Ignored if blank. Set a custom mongodb connection string.                          | `""` |
-| `mongodb.mongoSecretConnectionString.enableSecret`  |   If enabled, a Kubernetes secret is created from `mongodb.mongoConnectionString`. Use either enableSecret or enableCustomSecret, not both.    | `false` |
-| `mongodb.mongoSecretConnectionString.enableCustomSecret`  |   If enabled, an alternative secrets manager can be used by creating a custom Kubernetes secret. Use either enableSecret or enableCustomSecret, not both. `mongodb.mongoConnectionString` should be set to a dummy value.  | `false` |
-
+| Parameter                                                | Description                                                                                                                                             | Default         |
+|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| `mongodb.internal_db.enabled`                            | If enabled, it will deploy the internal MongoDB service.                                                                                                | `true`          |
+| `mongodb.external_db.enabled`                            | If enabled, it will allow you to use an external mongodb                                                                                                | `false`         |
+| `mongodb.external_db.mongoServer`                        | The mongo server when providing an external one. Use it with `mongodb.internal_db.enabled=false`                                                        | `""`            |
+| `mongodb.mongoDatabase`                                  | The mongo database                                                                                                                                      | `sorry-cypress` |
+| `mongodb.mongoConnectionString`                          | Ignored if blank. Set a custom mongodb connection string.                                                                                               | `""`            |
+| `mongodb.mongoSecretConnectionString.enableSecret`       | If enabled, a Kubernetes secret is created from `mongodb.mongoConnectionString`. Use either enableSecret or enableCustomSecret, not both.               | `false`         |
+| `mongodb.mongoSecretConnectionString.enableCustomSecret` | If enabled, an alternative secrets manager can be used by creating a custom Kubernetes secret. Use either enableSecret or enableCustomSecret, not both. | `false`         |
+| `mongodb.mongoSecretConnectionString.secretName`         | A custom secret name for the mongodb connection secret. Requires `mongodb.mongoSecretConnectionString.enableCustomSecret` to be true                    |                 | 
+| `mongodb.mongoSecretConnectionString.secretKey`          | A custom secret key used for the mongodb connection string. Requires `mongodb.mongoSecretConnectionString.enableCustomSecret` to be true                |                 | 
 
 All other mongodb options are defined in [the Bitnami mongo db helm chart](https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml).
 

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,3 +1,8 @@
+# 1.5.3
+Update
+Adds the possibility to specify a custom secret name and or secret key for the mongodb connection secret.
+Removes the necessity to set `mongodb.mongoConnectionString` to a dummy value when `mongodb.mongoSecretConnectionString.enableCustomSecret` is set to `true`.
+
 # 1.5.2
 Update
 Makes use of the /health-check-db endpoint on the director to provide a readiness probe.

--- a/charts/sorry-cypress/templates/deployment-api.yml
+++ b/charts/sorry-cypress/templates/deployment-api.yml
@@ -41,18 +41,22 @@ spec:
         {{- if or (.Values.mongodb.internal_db.enabled) (.Values.mongodb.external_db.enabled) }}
         - name: MONGODB_DATABASE
           value: {{ .Values.mongodb.mongoDatabase }}
-	{{- if .Values.mongodb.mongoConnectionString }}
         - name: MONGODB_URI
-        {{- if or (.Values.mongodb.mongoSecretConnectionString.enableSecret) (.Values.mongodb.mongoSecretConnectionString.enableCustomSecret) }}
+        {{-  $defaultConnectionSecretName := include "sorry-cypress-helm.fullname" . | printf "%s-mongodbsecrets" }}
+        {{-  $defaultConnectionSecretKey := "MONGODB_URI" }}
+        {{- if .Values.mongodb.mongoSecretConnectionString.enableCustomSecret }}
           valueFrom:
             secretKeyRef:
-              name: {{ include "sorry-cypress-helm.fullname" . }}-mongodbsecrets
-              key: MONGODB_URI
-        {{- else }}
+              name: {{ .Values.mongodb.mongoSecretConnectionString.secretName | default $defaultConnectionSecretName }}
+              key: {{ .Values.mongodb.mongoSecretConnectionString.secretKey | default $defaultConnectionSecretKey }}
+        {{- else if .Values.mongodb.mongoSecretConnectionString.enableSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $defaultConnectionSecretName }}
+              key: {{ $defaultConnectionSecretKey }}
+        {{- else if .Values.mongodb.mongoConnectionString }}
           value: {{ .Values.mongodb.mongoConnectionString }}
-        {{- end }}
-        {{- else }}
-        - name: MONGODB_URI
+        {{ else }}
           value: "mongodb://{{ include "mongodb.hostname" . }}:{{ .Values.mongodb.service.port }}"
         {{- end }}
         {{- end }}

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -47,17 +47,22 @@ spec:
         - name: MONGODB_DATABASE
           value: {{ .Values.mongodb.mongoDatabase }}
         - name: MONGODB_URI
-        {{- if .Values.mongodb.mongoConnectionString }}
-        {{- if or (.Values.mongodb.mongoSecretConnectionString.enableSecret) (.Values.mongodb.mongoSecretConnectionString.enableCustomSecret) }}
+        {{-  $defaultConnectionSecretName := include "sorry-cypress-helm.fullname" . | printf "%s-mongodbsecrets" }}
+        {{-  $defaultConnectionSecretKey := "MONGODB_URI" }}
+        {{- if .Values.mongodb.mongoSecretConnectionString.enableCustomSecret }}
           valueFrom:
             secretKeyRef:
-              name: {{ include "sorry-cypress-helm.fullname" . }}-mongodbsecrets
-              key: MONGODB_URI
-        {{- else }}
+              name: {{ .Values.mongodb.mongoSecretConnectionString.secretName | default $defaultConnectionSecretName }}
+              key: {{ .Values.mongodb.mongoSecretConnectionString.secretKey | default $defaultConnectionSecretKey }}
+        {{- else if .Values.mongodb.mongoSecretConnectionString.enableSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $defaultConnectionSecretName }}
+              key: {{ $defaultConnectionSecretKey }}
+        {{- else if .Values.mongodb.mongoConnectionString }}
           value: {{ .Values.mongodb.mongoConnectionString }}
-        {{- end }}
         {{ else }}
-          value:    "mongodb://{{ include "mongodb.hostname" . }}:{{ .Values.mongodb.service.port }}"
+          value: "mongodb://{{ include "mongodb.hostname" . }}:{{ .Values.mongodb.service.port }}"
         {{- end }}
         {{- end }}
         - name: SCREENSHOTS_DRIVER


### PR DESCRIPTION
## Description

This adds values named `mongodb.mongoSecretConnectionString.secretName` and `mongodb.mongoSecretConnectionString.secretKey` which allow specification of the mongodb connection secret name and key used for the `MONGODB_URI` environment variables of the `director` and `api`.

This allows the sorry cypress helm chart to integrate with custom MongoDB Connection Secret Sources.

These changes also remove the necessity to set `mongodb.mongoConnectionString` to a dummy value when `mongodb.mongoSecretConnectionString.enableCustomSecret` is set to `true`.

## Motivation

External MongoDBs might create secrets which do not conform to the default assumed secret name and key. E.g. the [MongoDB Community Kubernetes Operator](https://github.com/mongodb/mongodb-kubernetes-operator) creates secrets named `<metadata.name>-<auth-db>-<username>` corresponding to the created `MongoDBCommunity` resource.

These secrets might also use other keys e.g. `connectionString.standard` for their connection strings.