### PR TITLE
fix: match the mongodb hostname

### DIFF
--- a/charts/sorry-cypress/templates/_helpers.tpl
+++ b/charts/sorry-cypress/templates/_helpers.tpl
@@ -85,9 +85,9 @@ Create the mongoDB secret
 {{- define "mongodb.hostname" -}}
 {{- if .Values.mongodb.internal_db.enabled }}
   {{- if eq .Values.mongodb.architecture "standalone" }}
-  {{- printf "%s-%s" (include "sorry-cypress-helm.fullname" .) "mongodb" -}}
+  {{- printf "%s-%s" .Release.Name "mongodb" -}}
   {{- else }}
-  {{- printf "%s-%s" (include "sorry-cypress-helm.fullname" .) "mongodb-0" -}}
+  {{- printf "%s-%s" .Release.Name "mongodb-0" -}}
   {{- end }}
 {{- else }}
 {{- printf "%s" .Values.mongodb.external_db.mongoServer -}}


### PR DESCRIPTION
Motivation:

Rendering the template `helm template sc sorry-cypress/sorry-cypress` The mongo database name `sc-mongodb-0` doesn't match the `mongodb://sc-sorry-cypress-mongodb-0:27017` url

Modifications:

Use the `.Release.Name` instead of the full name in the `mongodb.hostname` template in `_helpers.tpl`

Results:

The mongodb hostname matches across the chart

Checklist:

* [] I have increased the chart version.
* [] I have updated the chart readme.
* [] I have updated the chart changelog.
* [] I have written CI tests for my change.
