### PR TITLE
Update apiVersion for CronJob and PodDisruptionBudget from v1beta1 to v1

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.7.3
+version: 1.7.4
 appVersion: 2.3.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,4 +1,7 @@
 
+# 1.7.4
+Update apiVersion for Cronjob template to `batch/v1` and PodDisruptionBudget to `policy/v1` since `v1beta1` is deprecated in v1.21+.
+
 # 1.7.3
 Allows to use  `priorityClassName` in all services.
 # 1.7.2

--- a/charts/sorry-cypress/templates/cronjob-run-cleaner.yml
+++ b/charts/sorry-cypress/templates/cronjob-run-cleaner.yml
@@ -1,5 +1,5 @@
 {{- if .Values.runCleaner.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:

--- a/charts/sorry-cypress/templates/poddisruptionbudget-api.yml
+++ b/charts/sorry-cypress/templates/poddisruptionbudget-api.yml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.api.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "sorry-cypress-helm.fullname" . }}-api

--- a/charts/sorry-cypress/templates/poddisruptionbudget-dashboard.yml
+++ b/charts/sorry-cypress/templates/poddisruptionbudget-dashboard.yml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.dashboard.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "sorry-cypress-helm.fullname" . }}-dashboard

--- a/charts/sorry-cypress/templates/poddisruptionbudget-director.yml
+++ b/charts/sorry-cypress/templates/poddisruptionbudget-director.yml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.director.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "sorry-cypress-helm.fullname" . }}-director


### PR DESCRIPTION
Update apiVersion for Cronjob template to `batch/v1` and PodDisruptionBudget to `policy/v1` . Version `v1beta1` is deprecated in v1.21+.

Checklist:

* [X] I have increased the chart version.
* [X] I have updated the chart changelog.
