### PR TITLE
Drop k8s 1.22. Add k8s 1.25

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -12,10 +12,9 @@ jobs:
     strategy:
       matrix:
         kubernetes_version:
-          - "kindest/node:v1.24.2"
-          - "kindest/node:v1.23.6"
-          - "kindest/node:v1.22.9"
-          # - "kindest/node:v1.21.10"
+          - "kindest/node:v1.25.2"
+          - "kindest/node:v1.24.6"
+          - "kindest/node:v1.23.12"
       fail-fast: true
 
     steps:


### PR DESCRIPTION
Checklist:

* [] I have increased the chart version.
* [] I have updated the chart readme.
* [] I have updated the chart changelog.
* [] I have written CI tests for my change.
