### PR TITLE
Allow extra environment variables for dashboard, director and api

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.13.1
+version: 1.13.2
 appVersion: 2.5.3
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/README.md
+++ b/charts/sorry-cypress/README.md
@@ -93,6 +93,7 @@ https://sorry-cypress.dev/api#configuration
 | `api.initContainers`                  | Allows you to define init container(s) for the api pod                                       | `[]`                        |
 | `api.enableApolloPlayground`          | Allows you to enable or disable Apollo Playground landing page                               | `false`                     |
 | `api.pageItemsLimit`                  | Allows you to set the API PAGE_ITEMS_LIMIT variable                                          | `10`                        |
+| `api.extraEnv`                        | Additional environment variables for the API container                                          | `[]`                        |
 
 ### Dashboard service
 
@@ -124,6 +125,7 @@ https://sorry-cypress.dev/dashboard#configuration
 | `dashboard.ingress.hosts[0].path`                         | Root path to the service installation                                                                      | `/`                               |
 | `dashboard.ingress.tls`                                   | Ingress secrets for TLS certificates                                                                       | `[]`                              |
 | `dashboard.initContainers`                                | Allows you to define init container(s) for the dashboard pod                                               | `[]`                              |
+| `dashboard.extraEnv`                                      | Additional environment variables for the Dashboard container                                          | `[]`                        |
 
 ### Director service
 
@@ -166,7 +168,8 @@ https://sorry-cypress.dev/director/configuration
 | `director.readinessProbe.periodSeconds`    | How often (in seconds) to perform the probe.                                                 | `5`                         |
 | `director.readinessProbe.timeoutSeconds`   | Number of seconds after which the probe times out.                                           | `3`                         |
 | `director.readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | `2`                         |
-| `director.readinessProbe.failureThreshold` | When a probe fails, Kubernetes will try `failureThreshold` times before giving up.           | `5`     
+| `director.readinessProbe.failureThreshold` | When a probe fails, Kubernetes will try `failureThreshold` times before giving up.           | `5`  
+| `director.extraEnv`                        | Additional environment variables for the Director container                                  | `[]`                        |   
 
 ### Mongodb service
 

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,6 +1,9 @@
 # 1.14
 - Update app to version `2.5.3`
 
+# 1.13.2
+- Add option to include addional environment variables for the director, dashboard and api containers
+
 # 1.13.1
 - Add option to add annotations and labels to the runCleaner cronjob pods
 - Allow to specify the container security context to the runCleaner cronjob pods

--- a/charts/sorry-cypress/templates/deployment-api.yml
+++ b/charts/sorry-cypress/templates/deployment-api.yml
@@ -76,6 +76,9 @@ spec:
           value: "mongodb://{{ include "mongodb.hostname" . }}:{{ .Values.mongodb.service.port }}"
         {{- end }}
         {{- end }}
+        {{- with .Values.api.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.api.image.pullPolicy }}
         name: {{ include "sorry-cypress-helm.fullname" . }}-api

--- a/charts/sorry-cypress/templates/deployment-dashboard.yml
+++ b/charts/sorry-cypress/templates/deployment-dashboard.yml
@@ -55,6 +55,9 @@ spec:
         {{- end }}
         - name: PORT
           value: "{{ .Values.dashboard.service.port }}"
+        {{- with .Values.api.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
         name: {{ include "sorry-cypress-helm.fullname" . }}-dashboard

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -161,6 +161,9 @@ spec:
           value: {{ .Values.director.environmentVariables.inactivityTimeoutSeconds | quote }}
         - name: GITLAB_JOB_RETRIES
           value: {{ .Values.director.environmentVariables.gitlabJobRetries | quote }}
+        {{- with .Values.api.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: "{{ .Values.director.image.repository }}:{{ .Values.director.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.director.image.pullPolicy }}
         name: {{ include "sorry-cypress-helm.fullname" . }}-director

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -105,7 +105,7 @@ api:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
-  
+
   extraEnv: []
     # - name: ENV_NAME
     #   value: ENV_VALUE
@@ -323,7 +323,7 @@ director:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
-  
+
   extraEnv: []
     # - name: ENV_NAME
     #   value: ENV_VALUE

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -105,6 +105,10 @@ api:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+  
+  extraEnv: []
+    # - name: ENV_NAME
+    #   value: ENV_VALUE
 
 dashboard:
   image:
@@ -191,6 +195,9 @@ dashboard:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+  extraEnv: []
+    # - name: ENV_NAME
+    #   value: ENV_VALUE
 
 director:
   serviceAccount:
@@ -316,6 +323,10 @@ director:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+  
+  extraEnv: []
+    # - name: ENV_NAME
+    #   value: ENV_VALUE
 
 mongodb:
   # You need to ensure that director.environmentVariables.executionDriver is set to "../execution/mongo/driver" if you want the director to use mongodb.


### PR DESCRIPTION
Allow extra environment variables for Dashboard, Director and API

Checklist:

* [X] I have increased [the chart version](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/Chart.yaml#L5).
* [X] I have updated the [chart readme](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/README.md) to reflect mny change.
* [X] I have updated the [chart changelog](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/changelog.md) to reflect my change.
* [X] I have updated/added any [CI tests](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/ci) to cover my change.
* [X] I have [Run the CI locally](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/contributing/README.md).
