### PR TITLE
fix: Correct extraEnv values for Director and Dashboard

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.13.2
+version: 1.13.3
 appVersion: 2.5.3
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,6 +1,9 @@
 # 1.14
 - Update app to version `2.5.3`
 
+# 1.13.3
+- Fixed extra environment variables for director and dashboard deployments
+
 # 1.13.2
 - Add option to include addional environment variables for the director, dashboard and api containers
 

--- a/charts/sorry-cypress/templates/deployment-dashboard.yml
+++ b/charts/sorry-cypress/templates/deployment-dashboard.yml
@@ -55,7 +55,7 @@ spec:
         {{- end }}
         - name: PORT
           value: "{{ .Values.dashboard.service.port }}"
-        {{- with .Values.api.extraEnv }}
+        {{- with .Values.dashboard.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag | default .Chart.AppVersion }}"

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -161,7 +161,7 @@ spec:
           value: {{ .Values.director.environmentVariables.inactivityTimeoutSeconds | quote }}
         - name: GITLAB_JOB_RETRIES
           value: {{ .Values.director.environmentVariables.gitlabJobRetries | quote }}
-        {{- with .Values.api.extraEnv }}
+        {{- with .Values.director.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         image: "{{ .Values.director.image.repository }}:{{ .Values.director.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
Correct the extraEnv values lookup for the Director and Dashboard deployments. 

Checklist:

* [X] I have increased [the chart version](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/Chart.yaml#L5).
* [X] I have updated the [chart readme](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/README.md) to reflect mny change.
* [X] I have updated the [chart changelog](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/changelog.md) to reflect my change.
* [X] I have updated/added any [CI tests](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/ci) to cover my change.
* [X] I have [Run the CI locally](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/contributing/README.md).
