### PR TITLE
Update topologyKey 

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.15.0
+version: 1.16.0
 appVersion: 2.5.3
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,3 +1,6 @@
+# 1.16
+- Update topologyKey to use `topology.kubernetes.io/zone`
+
 # 1.15
 - Set `runCleaner.tolerations` values
 

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -157,7 +157,7 @@ dashboard:
             labelSelector:
               matchLabels:
                 app: {{ include "sorry-cypress-helm.fullname" . }}-dashboard
-            topologyKey: failure-domain.beta.kubernetes.io/zone
+            topologyKey: topology.kubernetes.io/zone
 
   initContainers: []
 
@@ -259,7 +259,7 @@ director:
             labelSelector:
               matchLabels:
                 app: {{ include "sorry-cypress-helm.fullname" . }}-director
-            topologyKey: failure-domain.beta.kubernetes.io/zone
+            topologyKey: topology.kubernetes.io/zone
 
   # You can define any init container(s) here.
   # This example checks that mongodb is running before allowing the api pod to start.

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -51,7 +51,7 @@ api:
             labelSelector:
               matchLabels:
                 app: {{ include "sorry-cypress-helm.fullname" . }}-api
-            topologyKey: failure-domain.beta.kubernetes.io/zone
+            topologyKey: topology.kubernetes.io/zone
 
   # You can define any init container(s) here.
   # This example checks that mongodb is running before allowing the api pod to start.


### PR DESCRIPTION
Update failure-domain.beta.kubernetes.io/zone topologyKey to topolog.kubernetes.io/zone as the beta key has been deprecated for some time now (Since K8s 1.17) 

> Starting in v1.17, this label is deprecated in favor of [topology.kubernetes.io/zone](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone).

Thank you for offering a contribution to the Sorry Cypress Helm charts.

In order to ensure some level of quality, there are a few hoops to jump through. Please do not create a Pull Request until you have performed all these steps:

Checklist:

* [x] I have increased [the chart version](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/Chart.yaml#L5).
* [] I have updated the [chart readme](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/README.md) to reflect my change.
* [x] I have updated the [chart changelog](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/changelog.md) to reflect my change.
* [] I have updated/added any [CI tests](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/ci) to cover my change.
* [x] I have [Run the CI locally](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/contributing/README.md).
