### PR TITLE
chore: Remove tico24 as a named maintainer

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.16.0
+version: 1.16.1
 appVersion: 2.5.3
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -8,9 +8,6 @@ home: https://sorry-cypress.dev/
 sources:
   - https://github.com/sorry-cypress/sorry-cypress
 icon: https://s3.amazonaws.com/sorry-cypress.dev/static/logo.png
-maintainers:
-  - name: tico24
-    url: https://crumbhole.com
 dependencies:
   - name: minio
     repository: https://helm.min.io/

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,3 +1,6 @@
+# 1.16.1
+- Remove tico24 as named maintainer
+
 # 1.16
 - Update topologyKey to use `topology.kubernetes.io/zone`
 


### PR DESCRIPTION
I haven't done anything on the project for a while. It's not right that my nmame is there.

Thank you for offering a contribution to the Sorry Cypress Helm charts.

In order to ensure some level of quality, there are a few hoops to jump through. Please do not create a Pull Request until you have performed all these steps:

Checklist:

* [x] I have increased [the chart version](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/Chart.yaml#L5).
* [x] I have updated the [chart readme](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/README.md) to reflect mny change.
* [x] I have updated the [chart changelog](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/changelog.md) to reflect my change.
* [x] I have updated/added any [CI tests](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/ci) to cover my change.
* [x] I have [Run the CI locally](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/contributing/README.md).
