### PR TITLE
Fixed director readiness probe failing whend using BASE_PATH env

### DIFF
--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 1.19.0
+version: 1.19.1
 appVersion: 2.5.10
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/changelog.md
+++ b/charts/sorry-cypress/changelog.md
@@ -1,3 +1,6 @@
+# 1.19.1
+- Fixed director readiness probe failing when using BASE_PATH env
+
 # 1.19
 - Update app to version `2.5.10`
 

--- a/charts/sorry-cypress/templates/deployment-director.yml
+++ b/charts/sorry-cypress/templates/deployment-director.yml
@@ -161,6 +161,8 @@ spec:
           value: {{ .Values.director.environmentVariables.inactivityTimeoutSeconds | quote }}
         - name: GITLAB_JOB_RETRIES
           value: {{ .Values.director.environmentVariables.gitlabJobRetries | quote }}
+        - name: BASE_PATH
+          value: {{ .Values.director.environmentVariables.basePath | quote }}
         {{- with .Values.director.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -175,7 +177,7 @@ spec:
           {{- toYaml .Values.director.securityContext | nindent 10 }}
         readinessProbe:
           httpGet:
-            path: /health-check-db
+            path: {{ .Values.director.environmentVariables.basePath }}/health-check-db
             port: 1234
           periodSeconds: {{ .Values.director.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.director.readinessProbe.timeoutSeconds }}

--- a/charts/sorry-cypress/values.yaml
+++ b/charts/sorry-cypress/values.yaml
@@ -300,6 +300,9 @@ director:
     # Enable gitlab job retries
     gitlabJobRetries: false
 
+    # BASE_PATH serving path, usefull when using reverse proxy ex: /cypress/dashboard
+    basePath: ""
+
   # Set annotations for pods
   podAnnotations: {}
 


### PR DESCRIPTION
## Description
When setting `BASE_PATH` env variable to serve director from subpath (ex: reverse proxy to http://myhostname/cypress/dashboard), readiness probe was failing.

## Current behavior
Director health check was listening on `/my/base/path/health-check-db` while health check was made against `/heath-check-db` 

## Expected behavior
Health-check should run against `/my/base/path/health-check-db` when BASE_PATH is set.

## Checklist:

* [x] I have increased [the chart version](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/Chart.yaml#L5).
* [x] I have updated the [chart readme](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/README.md) to reflect mny change.
* [x] I have updated the [chart changelog](https://github.com/sorry-cypress/charts/blob/main/charts/sorry-cypress/changelog.md) to reflect my change.
* [x] I have updated/added any [CI tests](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/ci) to cover my change.
* [x] I have [Run the CI locally](https://github.com/sorry-cypress/charts/tree/main/charts/sorry-cypress/contributing/README.md).
